### PR TITLE
fix: use provided root path

### DIFF
--- a/src/components/NavigationTree/NavigationTree.tsx
+++ b/src/components/NavigationTree/NavigationTree.tsx
@@ -34,7 +34,7 @@ export function NavigationTree({
             <NavigationTreeDirectory
                 state={state}
                 dispatch={dispatch}
-                path=""
+                path={rootState.path}
                 fetchPath={fetchPath}
                 activePath={activePath}
                 onItemActivate={onActivePathUpdate}


### PR DESCRIPTION
If `rootState.path` is set to a non-empty string, the component breaks while trying to access fields of `state['']` in `NavigationTreeDirectory`, which are undefined, since there is no empty path in the tree.

This default empty value could be used for some purpose; in that case, please help me understand how to fix the described issue.