### PR TITLE
chore: add @yandex-cloud/uikit to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "peerDependencies": {
     "@yandex-cloud/browserslist-config": "^1.0.1",
     "@yandex-cloud/i18n": "^0.4.0",
+    "@yandex-cloud/uikit": "^1.8.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },


### PR DESCRIPTION
Project build fails without this package, yet it is not in production nor in peer dependencies