### PR TITLE
fix(NavigationTree): expand the tree to initial active path

### DIFF
--- a/src/components/NavigationTree/NavigationTree.tsx
+++ b/src/components/NavigationTree/NavigationTree.tsx
@@ -13,7 +13,7 @@ export function NavigationTree({
     getActions,
     activePath,
     onActivePathUpdate,
-    cache,
+    cache = true,
 }: NavigationTreeProps) {
     const [state, dispatch] = React.useReducer(reducer, {
         [partialRootState.path]: {

--- a/src/components/NavigationTree/NavigationTreeDirectory.tsx
+++ b/src/components/NavigationTree/NavigationTreeDirectory.tsx
@@ -44,7 +44,7 @@ export function NavigationTreeDirectory({
             .then((data) => {
                 dispatch({
                     type: NavigationTreeActionType.FinishLoading,
-                    payload: {path, data},
+                    payload: {path, activePath, data},
                 });
             })
             .catch((error) => {

--- a/src/components/NavigationTree/NavigationTreeDirectory.tsx
+++ b/src/components/NavigationTree/NavigationTreeDirectory.tsx
@@ -26,7 +26,7 @@ export function NavigationTreeDirectory({
     activePath,
     onItemActivate,
     getActions,
-    cache = true,
+    cache,
 }: NavigationTreeDirectoryProps) {
     const nodeState = state[path];
 

--- a/src/components/NavigationTree/state.ts
+++ b/src/components/NavigationTree/state.ts
@@ -63,8 +63,14 @@ export function reducer(state: NavigationTreeState = {}, action: NavigationTreeA
                     const name = item.name;
                     const type = item.type;
 
+                    // expand the tree according to the active path
+                    // prioritize the existing state to expand the tree only on first load
+                    const {activePath = ''} = action.payload;
+                    const collapsed = state[path]?.collapsed ?? !activePath.startsWith(`${path}/`);
+
                     newState[path] = {
                         ...getDefaultNodeState(),
+                        collapsed,
                         path,
                         name,
                         type,


### PR DESCRIPTION
I’m not sure whether this is a fix or a feature.
Seems to me like _not_ showing the node specified by the initial value of `activePath` is a bug. But we can discuss it.