### PR TITLE
chore: update @yandex-cloud/i18n to v0.6.0

### DIFF
--- a/.storybook/decorators/withLang.tsx
+++ b/.storybook/decorators/withLang.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {Story as StoryType, StoryContext} from '@storybook/react';
-import {I18N} from '@yandex-cloud/i18n';
+
+import {i18n} from '../../src/components/i18n';
 
 export function withLang(Story: StoryType, context: StoryContext) {
     const lang = context.globals.lang;
 
-    I18N.setDefaultLang(lang);
+    i18n.setLang(lang);
 
     return <Story key={lang} {...context} />;
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,14 @@
 import '@yandex-cloud/uikit/styles/styles.scss';
 
 import React from 'react';
-import {I18N} from '@yandex-cloud/i18n';
 import {ThemeProvider} from '@yandex-cloud/uikit';
+
+import {i18n} from '../src/components/i18n';
+
 import {withTheme} from './decorators/withTheme';
 import {withLang} from './decorators/withLang';
 
-I18N.setDefaultLang(I18N.LANGS.ru);
+i18n.setLang('ru');
 
 const withContextProvider = (Story, context) => {
     const theme = context.globals.theme;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5569,9 +5569,9 @@
       }
     },
     "@yandex-cloud/i18n": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@yandex-cloud/i18n/-/i18n-0.4.0.tgz",
-      "integrity": "sha512-AK5WEGsDedaHVZtT0rU8ueMnsMWJdzhIduHz/HkJMG0wnJOdH4H4Ux27v0Trwp2DsT5IyspS6PDiP5SHf3Tzpw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@yandex-cloud/i18n/-/i18n-0.6.0.tgz",
+      "integrity": "sha512-pkv5onR/acLDf2yZuErj3pqpF+QRfrHEuQibypSzWwvlWPGxeguYyPmratDqAw2Ci2zf1ysXu3SxBkkcxYLiXQ==",
       "dev": true
     },
     "@yandex-cloud/prettier-config": {
@@ -12831,8 +12831,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -13195,7 +13194,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -14360,8 +14358,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -15422,7 +15419,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15767,8 +15763,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-popper": {
       "version": "2.2.5",
@@ -15889,7 +15884,6 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/react-treeview/-/react-treeview-0.4.7.tgz",
       "integrity": "sha1-9kfgT3BJbrEfsJEsNRh+gOtg1Fg=",
-      "dev": true,
       "requires": {
         "prop-types": "^15.5.8"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react-treeview": "^0.4.3",
     "@yandex-cloud/browserslist-config": "^1.0.1",
     "@yandex-cloud/eslint-config": "^1.0.0",
-    "@yandex-cloud/i18n": "^0.4.0",
+    "@yandex-cloud/i18n": "^0.6.0",
     "@yandex-cloud/prettier-config": "^1.0.0",
     "@yandex-cloud/stylelint-config": "^1.1.0",
     "@yandex-cloud/tsconfig": "^1.0.0",
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@yandex-cloud/browserslist-config": "^1.0.1",
-    "@yandex-cloud/i18n": "^0.4.0",
+    "@yandex-cloud/i18n": "^0.6.0",
     "@yandex-cloud/uikit": "^1.8.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"

--- a/src/components/NavigationTree/i18n/index.ts
+++ b/src/components/NavigationTree/i18n/index.ts
@@ -1,10 +1,10 @@
-import {i18n, I18N} from '../../i18n';
+import {i18n} from '../../i18n';
 import en from './en.json';
 import ru from './ru.json';
 
 const COMPONENT = 'ydb-navigation-tree';
 
-i18n.registerKeyset(I18N.LANGS.en, COMPONENT, en);
-i18n.registerKeyset(I18N.LANGS.ru, COMPONENT, ru);
+i18n.registerKeyset('en', COMPONENT, en);
+i18n.registerKeyset('ru', COMPONENT, ru);
 
 export default i18n.keyset(COMPONENT);


### PR DESCRIPTION
`@yandex-cloud/i18n:0.6.0` introduces breaking changes: https://github.com/yandex-cloud/i18n/blob/a09a6b2b7c138e739f102a8361aa66368dc18c66/README.md#breaking-changes-in-060

However, this does not entails `ydb-ui-components` major upgrade. The reason is that all the features available in `@yandex-cloud/i18n:0.6.0` are also available in `@yandex-cloud/i18n:0.4.0` (while vice versa is not true). Breaking changes in the package correspond only to removing methods and fields. Hence `ydb-ui-components` can’t possibly introduce a code that would break a project that uses `@yandex-cloud/i18n:0.4.0`.