### PR TITLE
fix: add i18n export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/NavigationTree';
 export * from './components/TreeView';
+export {i18n} from './components/i18n';


### PR DESCRIPTION
`@yandex-cloud/i18n@^0.6.0` requires i18n setup via `.setLang()` on the i18n instance. To match the requirements, the i18n instance should be available to import from the package root.