### PR TITLE
chore: remove deprecated i18n export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
 export * from './components/NavigationTree';
 export * from './components/TreeView';
-// TODO: remove in the next major version
-export {i18n} from './components/i18n';
 export * from './utils';


### PR DESCRIPTION
This export was kept to maintain backward compatibility. Now with the major release it can be removed.