### PR TITLE
fix(NavigationTree): fix actions overflow

### DIFF
--- a/src/components/TreeView/TreeView.scss
+++ b/src/components/TreeView/TreeView.scss
@@ -77,8 +77,6 @@ $step-offset: 24px;
         margin-left: 6px;
 
         align-items: center;
-
-        overflow: hidden;
     }
 
     .tree-view_arrow {


### PR DESCRIPTION
Before:
<img width="327" alt="image" src="https://github.com/ydb-platform/ydb-ui-components/assets/45696255/49fe9c59-93af-46eb-b451-33ac3d4e9892">
After:
![image](https://github.com/ydb-platform/ydb-ui-components/assets/45696255/d6bc9b7d-ae5f-47c7-8159-6952a424a249)
